### PR TITLE
Warn when symbolic link with glob follow false

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
-var glob = require("glob"),
-	_ = require("lodash"),
-	minimatch = require("minimatch");
+var glob = require("glob");
+var _ = require("lodash");
+var minimatch = require("minimatch");
+var fs = require('fs');
+var path = require('path');
 
 /**
  * @function documentjs.find.files
@@ -61,6 +63,10 @@ module.exports = function(siteConfig){
 		glb.on = function(event, listener) {
 			if(event === "match") {
 				var handler = function(filepath){
+					var dir = path.dirname(filepath);
+					if( fs.lstatSync(dir).isSymbolicLink() && (globOptions.follow === false) ) {
+						console.warn("WARNING!!\n" + 'Detected symbolic link without `"follow": true` glob setting for ' + dir + "\n");
+					}
 					for(var i = 0; i < ignore.length; i++) {
 						if( minimatch(filepath, ignore[i]) ) {
 							return;


### PR DESCRIPTION
If someone symlinks a folder of source documentation without setting
glob.follow to true, they will probably be confused when it doesn't pick
up subdirectories within the symlinked folder, so show a warning.

This should be especially helpful when someone is trying to use `npm link`.

Currently the symlink check in this PR is kind of naive, and only checks the dirname of found documentation. If no documentation is found, or the dirname is something other than a symlink but there is still symlink in the path, this check will fail to detect the potential unexpected behavior.

Read about follow: true -> https://github.com/isaacs/node-glob#options